### PR TITLE
Update Project Link metadata (for PyPi)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     long_description=read_me,
     license="MIT",
-    url="https://github.com/joeyagreco/hn-api",
+    url="https://github.com/joeyagreco/hacker-news",
     include_package_data=True,
     packages=setuptools.find_packages(exclude=("test_e2e")),
     install_requires=required_packages,


### PR DESCRIPTION
Update project metadata to ensure that the latest Github project link is reflected in the PyPi page for this Python package.